### PR TITLE
Fix scroll bottom message display

### DIFF
--- a/src/main/java/view/custom_panels/MessageDisplayPanel.java
+++ b/src/main/java/view/custom_panels/MessageDisplayPanel.java
@@ -13,7 +13,7 @@ import interface_adapter.send_message.ChatViewModel;
 public class MessageDisplayPanel extends JPanel
 {
     private final JPanel boxPanel = new JPanel();
-
+    private JScrollPane scrollPane; // Keep a reference to the scroll pane
     public MessageDisplayPanel(List<MessagePanel> messagePanels)
     {
         // Set the layout of boxPanel to BoxLayout for vertical stacking
@@ -31,7 +31,7 @@ public class MessageDisplayPanel extends JPanel
         }
 
         // Create a JScrollPane to make the box panel scrollable
-        JScrollPane scrollPane = new JScrollPane(boxPanel);
+        scrollPane = new JScrollPane(boxPanel); // Store the scroll pane in an instance variable
         scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_ALWAYS);
         scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
 
@@ -43,6 +43,25 @@ public class MessageDisplayPanel extends JPanel
         // Set the layout of the main panel to BorderLayout and add the bordered panel
         this.setLayout(new BorderLayout());
         this.add(borderedPanel, BorderLayout.CENTER);
+        // Scroll to bottom after initialization
+        scrollToBottom();
+    }
+    // Add a method to access the scroll pane
+    public JScrollPane getScrollPane() {
+        return scrollPane;
+    }
+
+    // Add a method to scroll to the bottom
+    private void scrollToBottom()
+    {
+        SwingUtilities.invokeLater(new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                scrollPane.getVerticalScrollBar().setValue(scrollPane.getVerticalScrollBar().getMaximum());
+            }
+        });
     }
 
     /**
@@ -64,5 +83,8 @@ public class MessageDisplayPanel extends JPanel
         }
         boxPanel.revalidate();
         boxPanel.repaint();
+
+
+        scrollToBottom();
     }
 }

--- a/src/test/java/use_case/chat_refresh/ChatRefreshInteractorTest.java
+++ b/src/test/java/use_case/chat_refresh/ChatRefreshInteractorTest.java
@@ -1,0 +1,147 @@
+package use_case.chat_refresh;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import java.util.*;
+import entity.Message;
+import use_case.chat_refresh.*;
+
+public class ChatRefreshInteractorTest
+{
+
+    @Test
+    public void testExecuteSuccess()
+    {
+        // Arrange
+        Long threadID = 1L;
+        ChatRefreshInputData inputData = new ChatRefreshInputData(threadID);
+
+        // Create a mock thread data access object
+        MockChatRefreshThreadDataAccessInterface mockThreadDataAccess = new MockChatRefreshThreadDataAccessInterface();
+        mockThreadDataAccess.setMessages(Arrays.asList(
+                new Message("Hello", "user1", "2021-10-01 10:00:00"),
+                new Message("Hi", "user2", "2021-10-01 10:01:00")
+        ));
+
+        // Create a mock output boundary
+        MockChatRefreshOutputBoundary mockOutputBoundary = new MockChatRefreshOutputBoundary();
+
+        // Create interactor
+        ChatRefreshInteractor interactor = new ChatRefreshInteractor(mockThreadDataAccess, mockOutputBoundary);
+
+        // Act
+        interactor.execute(inputData);
+
+        // Assert
+        // Check that prepareSuccessView was called with correct data
+        assertTrue(mockOutputBoundary.successCalled);
+        List<String[]> expectedMessages = Arrays.asList(
+                new String[]{"user1", "Hello", "2021-10-01 10:00:00"},
+                new String[]{"user2", "Hi", "2021-10-01 10:01:00"}
+        );
+        assertEquals(expectedMessages.size(), mockOutputBoundary.outputData.getMessages().size());
+        for (int i = 0; i < expectedMessages.size(); i++) {
+            assertArrayEquals(expectedMessages.get(i), mockOutputBoundary.outputData.getMessages().get(i));
+        }
+
+        // Ensure that prepareFailView was not called
+        assertFalse(mockOutputBoundary.failCalled);
+    }
+
+    @Test
+    public void testExecuteException() {
+        // Arrange
+        Long threadID = 1L;
+        ChatRefreshInputData inputData = new ChatRefreshInputData(threadID);
+
+        // Create a mock thread data access object that throws an exception
+        MockChatRefreshThreadDataAccessInterface mockThreadDataAccess = new MockChatRefreshThreadDataAccessInterface();
+        mockThreadDataAccess.setThrowException(true);
+
+        // Create a mock output boundary
+        MockChatRefreshOutputBoundary mockOutputBoundary = new MockChatRefreshOutputBoundary();
+
+        // Create interactor
+        ChatRefreshInteractor interactor = new ChatRefreshInteractor(mockThreadDataAccess, mockOutputBoundary);
+
+        // Act
+        interactor.execute(inputData);
+
+        // Assert
+        // Check that prepareFailView was called with correct error message
+        assertTrue(mockOutputBoundary.failCalled);
+        assertTrue(mockOutputBoundary.errorMessage.contains("Simulated exception"));
+
+        // Ensure that prepareSuccessView was not called
+        assertFalse(mockOutputBoundary.successCalled);
+    }
+
+    @Test
+    public void testExecuteNoMessages() {
+        // Arrange
+        Long threadID = 1L;
+        ChatRefreshInputData inputData = new ChatRefreshInputData(threadID);
+
+        // Create a mock thread data access object that returns empty list
+        MockChatRefreshThreadDataAccessInterface mockThreadDataAccess = new MockChatRefreshThreadDataAccessInterface();
+        mockThreadDataAccess.setMessages(Collections.emptyList());
+
+        // Create a mock output boundary
+        MockChatRefreshOutputBoundary mockOutputBoundary = new MockChatRefreshOutputBoundary();
+
+        // Create interactor
+        ChatRefreshInteractor interactor = new ChatRefreshInteractor(mockThreadDataAccess, mockOutputBoundary);
+
+        // Act
+        interactor.execute(inputData);
+
+        // Assert
+        // Check that prepareSuccessView was called with empty messages
+        assertTrue(mockOutputBoundary.successCalled);
+        assertEquals(0, mockOutputBoundary.outputData.getMessages().size());
+
+        // Ensure that prepareFailView was not called
+        assertFalse(mockOutputBoundary.failCalled);
+    }
+
+    // Mock classes
+    private class MockChatRefreshThreadDataAccessInterface implements ChatRefreshThreadDataAccessInterface {
+        private List<Message> messages;
+        private boolean throwException = false;
+
+        public void setMessages(List<Message> messages) {
+            this.messages = messages;
+        }
+
+        public void setThrowException(boolean throwException) {
+            this.throwException = throwException;
+        }
+
+        @Override
+        public List<Message> getMessages(Long threadID) throws Exception {
+            if (throwException) {
+                throw new Exception("Simulated exception");
+            }
+            return messages;
+        }
+    }
+
+    private class MockChatRefreshOutputBoundary implements ChatRefreshOutputBoundary {
+        public boolean successCalled = false;
+        public boolean failCalled = false;
+        public ChatRefreshOutputData outputData;
+        public String errorMessage;
+
+        @Override
+        public void prepareSuccessView(ChatRefreshOutputData outputData) {
+            this.successCalled = true;
+            this.outputData = outputData;
+        }
+
+        @Override
+        public void prepareFailView(String errorMessage) {
+            this.failCalled = true;
+            this.errorMessage = errorMessage;
+        }
+    }
+}


### PR DESCRIPTION
Added unit tests for Chat Refresh Interactor.  

In addition, fixed MessageDisplay so that when the user refreshes or opens a thread it goes to the bottom where the most recent messages are.